### PR TITLE
reconnected.lua: localize tps()

### DIFF
--- a/data/computercraft/lua/rom/modules/main/reconnected.lua
+++ b/data/computercraft/lua/rom/modules/main/reconnected.lua
@@ -1,4 +1,4 @@
-function tps()
+local function tps()
     local h = http.get("https://api.reconnected.cc/tps")
     if not h then
         return 0, "Error contacting TPS API"


### PR DESCRIPTION
The tps() function was global if I'm reading this correctly.

I don't think this was intended, so let's change it.